### PR TITLE
Auto start on reboot

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,7 @@ before_fork do
   require 'puma_worker_killer'
 
   PumaWorkerKiller.config do |config|
-    config.ram           = ENV.fetch('PUMA_MAX_RAM') { 5000 } # mb
+    config.ram           = ENV['PUMA_MAX_RAM'].presence.to_i || 5000 # mb
     config.frequency     = 15    # seconds
     config.percent_usage = 0.95
     config.rolling_restart_frequency = 24 * 3600 # 12 hours in seconds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./etc/postgresql/postgresql.conf:/etc/postgresql/postgresql.conf
     expose:
       - '5432'
+    restart: on-failure:1
 
   redis:
     container_name: 'slp_redis'
@@ -19,12 +20,14 @@ services:
       - ./data/redis:/data
     expose:
       - '6379'
+    restart: on-failure:1
 
   memcached:
     container_name: 'slp_memcached'
     image: memcached:1.5.1-alpine
     expose:
       - '11211'
+    restart: on-failure:1
 
   elasticsearch:
     container_name: 'slp_elasticsearch'
@@ -34,6 +37,7 @@ services:
     expose:
       - '9200'
       - '9300'
+    restart: on-failure:1
 
   web:
     container_name: 'slp_web'
@@ -61,6 +65,7 @@ services:
     ports:
       - '80:80'
       - '443:443'
+    restart: on-failure:1
 
   app: &app_base
     image: registry.cn-hangzhou.aliyuncs.com/skylark/production:$SLP_VERSION
@@ -92,6 +97,7 @@ services:
     command: bundle exec puma -C config/puma.rb
     expose:
       - '3000'
+    restart: on-failure:1
 
   sidekiq:
     <<: *app_base

--- a/scripts/install
+++ b/scripts/install
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eux
 
+# https://docs.docker.com/install/linux/linux-postinstall/#configure-docker-to-start-on-boot
+sudo systemctl enable docker
+
 touch app.local.env
 docker-compose build
 docker-compose run app bundle exec rails db:create


### PR DESCRIPTION
https://github.com/GreenNerd/skylark-docker/issues/25

`restart: on-failure:1`，最大重试次数设置成1。我在本地测试，发现elasticsearch 重新启动过程中，puma会卡住。